### PR TITLE
docs. Dockerfile JAR_FILE 지정 배포테스트

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM adoptopenjdk:11-jdk-hotspot
 
-ARG JAR_FILE=build/libs/*.jar
+ARG JAR_FILE=build/libs/eventcafecloud-0.0.1-SNAPSHOT.jar
 
 COPY ${JAR_FILE} app.jar
 


### PR DESCRIPTION
JAR_FILE=build/libs/eventcafecloud-0.0.1-SNAPSHOT.jar로 지정함

기존에 JAR_FILE=build/libs/*.jar로 되어있었고 해당 파일 안에 2개의 jar파일이 들어있어 어떤 파일을 입력시켜야하는지 인식하지 못하여 에러가 발생함

# 📙 작업 내역

구현 내용 및 작업 했던 내역

- JAR_FILE=build/libs/eventcafecloud-0.0.1-SNAPSHOT.jar로 지정함
- 배포테스트 6
- 작업 내역 3
- 작업 내역 4

# 작업 유형

- [ ] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트

# 📋 체크리스트

- [ ] Merge 하는 브랜치가 올바른가?
- [ ] 코딩컨벤션을 준수하는가?
- [ ] PR과 관련없는 변경사항이 없는가?
- [ ] 내 코드에 대한 자기 검토가 되었는가?

# 📝 PR 특이 사항

PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 특이 사항 1
- 특이 사항 2