### PR TITLE
fix: 어드민페이지 포스트내용이 최신값 하나로만 불려져 오던 오류 수정

### DIFF
--- a/src/main/resources/templates/admin/fragments/manage-post.html
+++ b/src/main/resources/templates/admin/fragments/manage-post.html
@@ -68,7 +68,7 @@
                                               method="post"
                                               th:action="@{/admin/posts/{id}/update(id=${post.getId})}"
                                               th:object="${PostStatusUpdateRequestDto}">
-                                            <button class="pass-button" data-target="#exampleModalCenter"
+                                            <button class="pass-button" th:data-target="'#'+${post.getId}"
                                                     data-toggle="modal"
                                                     type="button">
                                                 확인
@@ -76,7 +76,7 @@
                                             <!-- Modal -->
                                             <div aria-hidden="true" aria-labelledby="exampleModalCenterTitle"
                                                  class="modal fade"
-                                                 id="exampleModalCenter"
+                                                 th:id="${post.getId}"
                                                  role="dialog" tabindex="-1">
                                                 <div class="modal-dialog modal-dialog-centered" role="document">
                                                     <div class="modal-content">


### PR DESCRIPTION
  - 내용버튼을 누르면, 해당 포스트에 일치하는 내용을 불러오도록 수정

# 📙 작업 내역
어드민페이지 포스트내용이 최신값 하나로만 불려져 오던 오류 수정

